### PR TITLE
Add `Save on Build`

### DIFF
--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -14,6 +14,8 @@ class Builder extends Disposable
 
     @killProcess()
     @setCmds()
+    if atom.config.get('atom-latex.save_on_build')
+      @saveonBuild()
     @latex.logger.log = []
     @latex.package.status.view.status = 'building'
     @latex.package.status.view.update()
@@ -22,6 +24,13 @@ class Builder extends Disposable
     @buildProcess()
 
     return true
+
+  saveonBuild: ->
+    if !@latex?.texFiles
+      @latex.manager.findAll()
+    for editor in atom.workspace.getTextEditors()
+      if editor.isModified() and editor.getPath() in @latex.texFiles
+        editor.save()
 
   execCmd: (cmd, env, cb) ->
     env.maxBuffer = Infinity

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -55,16 +55,22 @@ module.exports =
     description: 'Start building with toolchain after saving a `.tex` file.'
     type: 'boolean'
     default: true
+  save_on_build:
+    title: 'Save files before Build'
+    order: 8
+    description: 'Save all files in current document prior building LateX'
+    type: 'boolean'
+    default: false
   focus_viewer:
     title: 'Focus PDF viewer window after building'
-    order: 8
+    order: 9
     description: 'PDF viewer window will gain focus after building LaTeX or \
                   forward SyncTeX.'
     type: 'boolean'
     default: false
   preview_after_build:
     title: 'Preview PDF after building process'
-    order: 9
+    order: 10
     description: 'Use PDF viewer to preview the generated PDF file after \
                   successfully building LaTeX.'
     type: 'string'
@@ -76,7 +82,7 @@ module.exports =
     ]
   combine_typesetting_log:
     title: 'Combine typesetting log messages'
-    order: 10
+    order: 11
     description: 'Combine typesetting log messages in log panel. Sometimes \
                   typesetting messages may clutter the panel. Enable this \
                   config to display one message for all typesetting entries.'
@@ -84,7 +90,7 @@ module.exports =
     default: true
   hide_log_if_success:
     title: 'Hide LaTeX log messages on successful build'
-    order: 11
+    order: 12
     description: 'Hide the LaTeX log panel if the build process is successful. \
                   This will save some space for the editor, but warnings are \
                   hidden unless manually click the `Show build log` icon.'
@@ -92,7 +98,7 @@ module.exports =
     default: false
   file_ext_to_clean:
     title: 'Files to clean'
-    order: 12
+    order: 13
     description: 'All files under the LaTeX project root directory with the set\
                   extensions will be removed when cleaning LaTeX project. \
                   Multiple file extensions are joint with commas.'
@@ -102,14 +108,14 @@ module.exports =
               *.fdb_latexmk'
   clean_after_build:
     title: 'Clean LaTeX auxillary files after building process'
-    order: 13
+    order: 14
     description: 'Clean all auxillary files after building LaTeX project by \
                   the defined file extensions.'
     type: 'boolean'
     default: false
   delayed_minimap_refresh:
     title: 'Delay the refresh actions of atom-minimap'
-    order: 14
+    order: 15
     description: 'Delay the refresh actions of atom-minimap upon typing. This \
                   setting can reduce the keystroke stuttering in very long \
                   LaTeX source files caused by minimap extension. Reload Atom \


### PR DESCRIPTION
Save all unsaved open files that belong to current document prior to build

Upon `Build`, check if any modified editor tabs belong to current document using `@latex.texFiles` from `@latex.manager.findAll()` and if the option is enabled, save the files before building.

Packages like [`atom-build`](https://github.com/noseglid/atom-build) has a confirmation dialog that pops up if the default setting is not set, however I think that might be bit obtrusive in a normal LaTeX workflow. What do you think?
