### PR TITLE
Issue #31 - Fix when building from outside `ActiveTextEditor`

### DIFF
--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -8,7 +8,8 @@ class Manager extends Disposable
     @latex = latex
 
   loadLocalCfg: ->
-    if @lastCfgTime? and Date.now() - @lastCfgTime < 200
+    if @lastCfgTime? and Date.now() - @lastCfgTime < 200 or\
+       !atom.workspace.getActiveTextEditor()?
       return @config?
     @lastCfgTime = Date.now()
     rootDir = atom.project.relativizePath(atom.workspace.getActiveTextEditor().getPath())[0]


### PR DESCRIPTION
Updating #35  to fix the case when you build using either the status bar or the package menu and not from the active editor pane.