### PR TITLE
Use `chokidar` to watch files and folders

### DIFF
--- a/lib/autocomplete/citation.coffee
+++ b/lib/autocomplete/citation.coffee
@@ -83,5 +83,5 @@ class Citation extends Disposable
       bibItem[key] = value
     return bibItem
 
-  resetBibItems:(bib) ->
+  resetBibItems: (bib) ->
     delete @items[bib]

--- a/lib/autocomplete/reference.coffee
+++ b/lib/autocomplete/reference.coffee
@@ -7,6 +7,7 @@ class Reference extends Disposable
   constructor: (latex) ->
     @latex = latex
     @suggestions = []
+    @items = []
 
   provide: (prefix) ->
     suggestions = []
@@ -22,9 +23,8 @@ class Reference extends Disposable
     if !@latex.manager.findAll()
       return suggestions
 
-    items = []
-    for tex in @latex.texFiles
-      items = items.concat @getRefItems tex
+    # for tex in @latex.texFiles
+    #   items = items.concat @getRefItems tex
 
     editor = atom.workspace.getActivePaneItem()
     currentPath = editor?.buffer.file?.path
@@ -32,9 +32,9 @@ class Reference extends Disposable
 
     if currentPath and currentContent
       if @latex.manager.isTexFile(currentPath)
-        items = items.concat @getItems currentContent
+        @items = @items.concat @getItems currentContent
 
-    for item in items
+    for item in @items
       suggestions.push
         text: item
         type: 'tag'
@@ -59,4 +59,7 @@ class Reference extends Disposable
     if !fs.existsSync(tex)
       return []
     content = fs.readFileSync tex, 'utf-8'
-    return @getItems(content)
+    @items = @items.concat @getItems(content)
+
+  resetRefItems: ->
+    @items = []

--- a/lib/autocomplete/subFiles.coffee
+++ b/lib/autocomplete/subFiles.coffee
@@ -38,10 +38,10 @@ class SubFiles extends Disposable
     try
       if !images and !splice?
         relPath = path.relative(dirName,file)
-        # console.log "File: #{relPath} added to suggestion"
         extType = path.extname(relPath)
         @items.push
-         text: relPath.substr(
+         text: relPath.replace(/\\/g, "/").replace(/(\.tex)/g,"")
+         displayText: relPath.substr(
                   0, relPath.lastIndexOf('.')).replace( /\\/g, "/")
          rightLabel: extType.replace(".", "")
          iconHTML: """<i class="#{if extType of FileTypes then FileTypes[extType] else  "icon-file-text"}"></i>"""
@@ -70,7 +70,7 @@ class SubFiles extends Disposable
 
   resetFileItems: ->
     @items = []
-    
+
 # Use file-icons as default with Git Octicons as backups
 ImageTypes =
   '.png':   "medium-orange icon-file-media"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "latex-symbols-list": "^0.1.2",
     "tmp": "^0.0.31",
     "ws": "^1.1.1",
-    "fs-plus": "^2.3.0"
+    "fs-plus": "^2.3.0",
+    "chokidar": "^1.6.0"
   }
 }


### PR DESCRIPTION
Further to #41 - have implemented `chokidar` but a bit differently. 

The basic idea is that the entire `rootDir` is watched for files of interest that match common `tex` and `image` extensions, along with custom file extensions from the `.latexcfg` file 

Hence, there are multiple `chokidar.watch()` objects, one for the `rootDir` and one for the **each** `bibFile` found in the main tex file. 

### File handling 

#### LaTeX Files
On `change` events the watched file is parsed, and suggestions for references and command autocomplete is collected. 
On `add` and `unlink` events autocomplete file suggestions are added or removed for the corresponding file. 

#### Image Files
Only `add` and `unlink` events are tracked for images, and autocomplete file suggestions are added or removed for the corresponding file. 

### To dos and discussions 
- [ ] Profile and check for performance 
- [x] Implement a per file ~`resetCommands()`~ and `resetRefItems()` for an 'unlink' event
- [ ] Add additional spec checks (Have no idea about this :-P )

1.  When dependant files are be parsed only on changes, a `change` event has to be triggered in the dependant file before suggestions are available. To overcome this currently,`findDependentFiles` triggers parsing of all files on each `change` on the `mainFile` leading to some unnecessary parsing of unchanged files   
 
1. ???

PS: I have left some debugging statements, will clean up after your review!
