### PR TITLE
Multi-file handling improvements and minor tweaks

### DIFF
--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -16,6 +16,7 @@ class Builder extends Disposable
     @setCmds()
     if atom.config.get('atom-latex.save_on_build')
       @saveonBuild()
+    @buildTimer = Date.now()
     @latex.logger.log = []
     @latex.package.status.view.status = 'building'
     @latex.package.status.view.update()
@@ -86,7 +87,7 @@ class Builder extends Disposable
     if @latex.parser.isLatexmkSkipped
       logText = 'latexmk skipped building process.'
     else
-      logText = 'Successfully built LaTeX.'
+      logText = "Successfully built LaTeX in #{Date.now() - @buildTimer} ms"
     @latex.logger.log.push({
       type: 'status',
       text: logText

--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -6,10 +6,19 @@ chokidar = require 'chokidar'
 module.exports =
 class Manager extends Disposable
   rootDir: ->
-    if atom.workspace.getActiveTextEditor()?
+    # Collect all open TextEditors with  LaTeX grammar
+    texEditors = (editor for editor in atom.workspace.getTextEditors()\
+                    when editor.getGrammar().scopeName.match(/text.tex.latex/))
+    if atom.workspace.getActiveTextEditor()? # An active editor is open
       return atom.project.relativizePath(atom.workspace.getActiveTextEditor().getPath())[0]
-    else
-      return atom.project.getPaths()[0] # backup, return first active project
+    else if texEditors.length > 0   # First open editor with LaTeX grammar
+      return atom.project.relativizePath(texEditors[0].getPath())[0]
+    else # backup, return first active project
+        @latex.logger.log.push {
+          type: status
+          text: "No active TeX editors were open - Setting Project: #{atom.project.getPaths()[0]}"
+        }
+      return atom.project.getPaths()[0]
   constructor: (latex) ->
     @latex = latex
 

--- a/lib/viewer.coffee
+++ b/lib/viewer.coffee
@@ -39,7 +39,7 @@ class Viewer extends Disposable
       atom.workspace.paneForItem(@tabView).destroyItem(@tabView)
       @openViewerNewTab()
       return
-    else if @window? and @window.getTitle() isnt newTitle
+    else if @window? and !@window.isDestroyed() and @window.getTitle() isnt newTitle
       @window.setTitle("""Atom-LaTeX PDF Viewer - [#{@latex.mainFile}]""")
     @client.ws?.send JSON.stringify type: "refresh"
 

--- a/spec/main-spec.coffee
+++ b/spec/main-spec.coffee
@@ -18,6 +18,9 @@ describe 'Atom-LaTeX', ->
         expect(pkg.latex.server).toBeDefined()
         expect(pkg.latex.panel).toBeDefined()
         expect(pkg.latex.parser).toBeDefined()
+        expect(pkg.latex.locator).toBeDefined()
+        expect(pkg.latex.logger).toBeDefined()
+        expect(pkg.latex.cleaner).toBeDefined()
 
   describe 'Builder', ->
     beforeEach ->
@@ -116,6 +119,7 @@ describe 'Atom-LaTeX', ->
       execCmd = execCmd_ = open = open_ = undefined
 
       beforeEach ->
+        waitsForPromise -> atom.packages.activatePackage('status-bar')
         open = jasmine.createSpy('open')
         stdout = jasmine.createSpy('stdout')
         execCmd = jasmine.createSpy('execCmd').andCallFake((cmd, cwd, fn) ->
@@ -140,7 +144,7 @@ describe 'Atom-LaTeX', ->
         helper.unsetConfig 'atom-latex.bibtex'
         helper.unsetConfig 'atom-latex.compiler_param'
         helper.unsetConfig 'atom-latex.custom_toolchain'
-        helper.setConfig 'atom-latex.preview_after_build', false
+        helper.setConfig 'atom-latex.preview_after_build', 'Do nothing'
         pkg.latex.builder.build()
         expect(execCmd.callCount).toBe(4)
         expect(open).not.toHaveBeenCalled()


### PR DESCRIPTION
Combining a few things in this PR.

### 1. Multi-project support 
Have introduced a more robust attempt at multi-project support compared to the [initial implementation ](https://github.com/James-Yu/Atom-LaTeX/pull/47/files#diff-c9b4f199851474c585bd505761e0123dR8) 
This should reduce issues such as #45 

The `rootDir` is determined in the following hierarchy:
1. Use active editor if available.
1. Use the first open editor that has LaTeX grammar
1. Use first open Atom project - inform user via log

This should also implicitly address issues with the PDF viewer tabs like #63  and #64 as now the assumption that the active pane always is belongs to the main project is not made. 

### 2. Log LaTeX build time

Given #58, a minor tweak to keep tab of such metrics.

### 3. Tweak folder watcher 

1. Folder watching can be disabled by setting a `disable_watcher` key to `true` under `atom-latex` in user configuration (`config.cson`)
1. Tweaked the `chokidar` folder watch implementation by using the`ignored` option with Regex instead of watching globs

### To dos and discussions 
1. ~Package tests fail - but I am unable to reproduce the error in the dev environment. I admit I didn't look into it too much, but maybe you have some ideas already?~
```
Atom-LaTeX
  Builder
    ::build
      it should execute all commands sequentially
        TypeError: Cannot read property 'view' of undefined
          at Builder.module.exports.Builder.build (file:///C:/Users/dev/.atom/dev/packages/Atom-LaTeX/lib/builder.coffee:21:26)
          at .<anonymous> (file:///C:/Users/Ash/.atom/dev/packages/atom-latex/spec/main-spec.coffee:144:27)
      it should open preview when ready if enabled
        TypeError: Cannot read property 'view' of undefined
          at Builder.module.exports.Builder.build (file:///C:/Users/dev/.atom/dev/packages/Atom-LaTeX/lib/builder.coffee:21:26)
          at .<anonymous> (file:///C:/Users/Ash/.atom/dev/packages/atom-latex/spec/main-spec.coffee:155:27)


Finished in 3.626 seconds
13 tests, 24 assertions, 2 failures, 0 skipped
```
2. Do you see any advantages of this `rootDir` determination method, or do we revert to iterating all open projects as in 673affc6b86636051fb73a9f1ad3050ef82714ab? 


