### PR TITLE
Fix failures due to buffer.lines being undefined

### DIFF
--- a/lib/autocomplete/syntax.coffee
+++ b/lib/autocomplete/syntax.coffee
@@ -18,11 +18,11 @@ class Syntax extends Disposable
 
     cursor = editor.getCursorBufferPosition()
     allowedNextChar = [' ', '.']
-    if editor?.buffer?.lines[cursor.row][cursor.column - 1] is ' ' or \
-        editor?.buffer?.lines[cursor.row].length is 0
-      if editor?.buffer?.lines[cursor.row].length is cursor.column or \
-          allowedNextChar.indexOf(
-            editor?.buffer?.lines[cursor.row][cursor.column]) > -1
+    lines = editor.getBuffer().getLines()
+    if lines[cursor.row][cursor.column - 1] is ' ' or \
+        lines[cursor.row].length is 0
+      if lines[cursor.row].length is cursor.column or \
+          allowedNextChar.indexOf(lines[cursor.row][cursor.column]) > -1
         editor.insertText('$$')
         editor.moveLeft()
         return

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -45,12 +45,12 @@ class Provider extends Disposable
         setTimeout(( -> atom.packages.getActivePackage('autocomplete-plus')\
           .mainModule.autocompleteManager.findSuggestions()), 100)
       if suggestion.latexType is 'environment'
-        rowContent = editor.buffer.lines[triggerPosition.row].slice(
-          0, triggerPosition.column)
+        lines = editor.getBuffer().getLines()
+        rowContent = lines[triggerPosition.row].slice(0, triggerPosition.column)
         if rowContent.indexOf('\\end') > rowContent.indexOf('\\begin')
           editor.setCursorBufferPosition(
             row: triggerPosition.row - 1
-            column: editor.buffer.lines[triggerPosition.row - 1].length
+            column: lines[triggerPosition.row - 1].length
           )
           if suggestion.additionalInsert?
             editor.insertText(suggestion.additionalInsert)


### PR DESCRIPTION
Fixes two seemingly separate issues I am seeing on Atom 1.20.0-dev: (1) when you enter a dollar sign you get an error, (2) #82.

This switches the code to using proper getter functions instead, which seems to fix the problem.