### PR TITLE
Stop stripping mainFiles extension before build

### DIFF
--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -151,7 +151,8 @@ class Builder extends Disposable
       cmd = cmd.split('%BIB').join(bibCompiler)
       cmd = cmd.split('%ARG').join(args)
       cmd = cmd.split('%DOC').join(
-        @escapeFileName(path.basename(@latex.mainFile))
+        # get basename and strip .tex extension for bibtex compitability
+        @escapeFileName(path.basename(@latex.mainFile).replace(/\.tex$/, ''))
       )
       @cmds.push cmd
 

--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -151,7 +151,7 @@ class Builder extends Disposable
       cmd = cmd.split('%BIB').join(bibCompiler)
       cmd = cmd.split('%ARG').join(args)
       cmd = cmd.split('%DOC').join(
-        @escapeFileName(path.basename(@latex.mainFile).replace(/\.[^/.]+$/,""))
+        @escapeFileName(path.basename(@latex.mainFile))
       )
       @cmds.push cmd
 

--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -44,7 +44,7 @@ class Manager extends Disposable
 
   isTexFile: (name) ->
     @latex.manager.loadLocalCfg()
-    if path.extname(name) == '.tex' or \
+    if path.extname(name) == '.tex' or path.extname(name) == '.tikz' or \
         @latex.manager.config?.latex_ext?.indexOf(path.extname(name)) > -1
       return true
     return false

--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -44,7 +44,7 @@ class Manager extends Disposable
 
   isTexFile: (name) ->
     @latex.manager.loadLocalCfg()
-    if path.extname(name) == '.tex' or path.extname(name) == '.tikz' or \
+    if path.extname(name) == '.tex' or \
         @latex.manager.config?.latex_ext?.indexOf(path.extname(name)) > -1
       return true
     return false


### PR DESCRIPTION
As of now, the extension of the main file is stripped before compilation. Thus, `example.tex` will result in a command like `pdflatex example`.
This works fine for `.tex` files, as `pdflatex` will search for both `example` and `example.tex`. However it fails at custom extensions, like `.tikz`.

This commit removes the stripping of the main files extension. So, `example.tikz` would be passed to pdflatex as it is.

Related issue: https://github.com/James-Yu/Atom-LaTeX/issues/86