### PR TITLE
Regard .tikz files as TeX files as well

### DIFF
--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -44,7 +44,7 @@ class Manager extends Disposable
 
   isTexFile: (name) ->
     @latex.manager.loadLocalCfg()
-    if path.extname(name) == '.tex' or \
+    if path.extname(name) == '.tex' or path.extname(name) == '.tikz' or \
         @latex.manager.config?.latex_ext?.indexOf(path.extname(name)) > -1
       return true
     return false


### PR DESCRIPTION
For those of us, who work with a lot of TikZ graphics, having multiple `.latexcfg`s to support the `.tikz` extension for every image in each folder can be quite a hassle.

This could be eased by looking for `.latexcfg` in a parent directory as in https://github.com/James-Yu/Atom-LaTeX/issues/72.

Otherwise, the common `.tikz` extension could be supported natively, as already I proposed in https://github.com/James-Yu/Atom-LaTeX/issues/86.

I know this is debatable, so feel free to consider this.