### PR TITLE
Multiple small improvements 

### DIFF
--- a/lib/autocomplete/citation.coffee
+++ b/lib/autocomplete/citation.coffee
@@ -84,4 +84,8 @@ class Citation extends Disposable
     return bibItem
 
   resetBibItems: (bib) ->
-    delete @items[bib]
+    # Remove specific or all citation suggestions
+    if bib?
+      delete @items[bib]
+    else
+      @items = []


### PR DESCRIPTION
This PR combines two fixes (Unrelated but I pushed them all to the same repo - sorry!)

### 1. Fix citations for multi-file projects
This should fix #80 
Have restructured the implantation of the `bibwatcher` (along the lines of LaTeX Workshop) that should now result in faster parsing and seamless switching between multiple open LaTeX projects.

### 2. Switch to `child_process.spawn`
This fixes #54 
Have tweaked the logging a bit to utilise more icons 
