### PR TITLE
Open external PDF links in default browser

### DIFF
--- a/lib/viewer.coffee
+++ b/lib/viewer.coffee
@@ -29,6 +29,8 @@ class Viewer extends Disposable
         @latex.locator.locate(data)
       when 'close'
         @client.ws = undefined
+      when 'link' # Open link externally
+        require('electron').shell.openExternal(data.href)
 
   refresh: ->
     newTitle = path.basename("""#{@latex.mainFile.substr(

--- a/viewer/web/latex.js
+++ b/viewer/web/latex.js
@@ -58,3 +58,13 @@ document.addEventListener('pagerendered', (e) => {
         socket.send(JSON.stringify({type:"click", path:file, pos:pos, page:page}));
     }
 }, true);
+
+// Open links externally
+// identified by target set from PDFJS.LinkTarget.TOP
+document.addEventListener('click', (e) => {
+    var srcElement = e.srcElement;
+    if (srcElement.href != undefined && srcElement.target == '_top'){
+      e.preventDefault()
+      socket.send(JSON.stringify({type:"link",href:srcElement.href}));
+    }
+});


### PR DESCRIPTION
Fix for #87 

### Discussions
1. What should the default behavior to open the link be?
a) <kbd>ctrl</kbd>+<kbd>Mouse Click</kbd>
b) <kbd>Mouse Click</kbd>

2. Is there a better event type to attach a listener to? 
 The current implantation is attached to the `click` event - not the most elegant solution, but is the limit of my JS skills ;-)