### PR TITLE
Add `.bib` to subfile-autocomplete 

### DIFF
--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -157,7 +157,7 @@ class Manager extends Disposable
         type: status
         text: "Watching project #{root} for changes"
       }
-      watchFileExts = ['png','eps','jpeg','jpg','pdf','tex']
+      watchFileExts = ['png','eps','jpeg','jpg','pdf','tex','bib']
       if @latex.manager.config?.latex_ext?
         watchFileExts.push @latex.manager.config.latex_ext...
       @rootWatcher = chokidar.watch(root,{
@@ -191,9 +191,9 @@ class Manager extends Disposable
   watchActions: (fpath,event) ->
     # Push/Splice file suggestions on new file additions or removals
     if event is 'add'
-      @latex.provider.subFiles.getFileItems(fpath, !@isTexFile(fpath))
+      @latex.provider.subFiles.getFileItems(fpath)
     else if event is 'unlink'
-      @latex.provider.subFiles.getFileItems(fpath,false,true) # don't bother checking file type
+      @latex.provider.subFiles. resetFileItems(fpath) 
       @latex.provider.reference.resetRefItems(fpath)
     if @isTexFile(fpath)
       # Push command and references suggestions

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -70,7 +70,7 @@ class Provider extends Disposable
         reg = /\\([a-zA-Z]*)$/
         provider = @command
       when 'subFiles'
-        reg = /(?:\\(?:input|include|subfile|includegraphics)(?:\[[^\[\]]*\])?){([^}]*)$/
+        reg = /(?:\\(?:input|include|subfile|includegraphics|addbibresource)(?:\[[^\[\]]*\])?){([^}]*)$/
         provider = @subFiles
 
     result = line.match(reg)
@@ -82,6 +82,9 @@ class Provider extends Disposable
         allKeys = prefix.split(',')
         currentPrefix = allKeys[allKeys.length - 1].trim()
       suggestions = provider.provide(currentPrefix)
-      if ['subFiles'].indexOf(type) > -1 and line.match(/(?:\\(?:includegraphics)(?:\[[^\[\]]*\])?){([^}]*)$/)
-        suggestions = provider.provide(currentPrefix,true)
+      if type == 'subFiles'
+        if line.match(/(?:\\(?:includegraphics)(?:\[[^\[\]]*\])?){([^}]*)$/)
+          suggestions = provider.provide(currentPrefix,'files-img')
+        else if line.match(/(?:\\(?:addbibresource)(?:\[[^\[\]]*\])?){([^}]*)$/)
+          suggestions = provider.provide(currentPrefix,'files-bib')
     return suggestions


### PR DESCRIPTION
### New feature 
Autocomplete `.bib` files in current project dir for `\addbibresource{}`

Also streamlined the `subFiles` provider code a bit.

Cheers!


#### For changelog (Changed)
`[(#98)](https://github.com/James-Yu/Atom-LaTeX/pull/98)  Add ``.bib`` to subfile-autocomplete + code clean up`