### PR TITLE
Add error notification for invalid LaTeX root file

### DIFF
--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -51,6 +51,17 @@ class Manager extends Disposable
 
   findMain: (here) ->
     result = @findMainSequence(here)
+    if !fs.existsSync(@latex.mainFile)
+      @latex.logger.processError(
+        "Invalid LaTeX root file `#{path.basename(@latex.mainFile)}`",
+        "The path #{@latex.mainFile} does not exist!", true,
+        [{
+          text: "Set LaTeX root"
+          onDidClick: =>
+            @latex.manager.refindMain()
+            @latex.logger.clearBuildError()
+        }])
+      return false
     @latex.panel.view.update()
     return result
 


### PR DESCRIPTION
Throw an error when an invalid `mainFile` is set, or e.g via magic commands. 

Should help in cases such as #99 

