### PR TITLE
Kill all children process

### DIFF
--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -131,6 +131,11 @@ class Builder extends Disposable
         type: 'warning',
         text: "Killing running LaTeX command (PID: #{@currentProcess.pid})"
       })
+      # Kill entire process tree
+      if process.platform is 'win32'
+        cp.exec("taskkill -pid #{@currentProcess.pid} /T /F")
+      else
+        cp.exec("pkill -P #{@currentProcess.pid}")  
       @currentProcess.kill()
 
   binCheck: (binary) ->

--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -79,18 +79,18 @@ class Builder extends Disposable
         err =
           code: exitCode
           message: if @buildErrs.length > 1 then @buildErrs else  "Command Failed: " + cmd
-        throwErrors(err)
+        throwErrors(err,'Build Aborted!' if signal?)
         # Parse last command's log
         @latex.parser.parse @buildLogs?[@buildLogs?.length - 1]
         # Clear pending commands and currentProcess
         @cmds = []
       @currentProcess = undefined
 
-    throwErrors = (err) =>
+    throwErrors = (err,title) =>
       @latex.package.status.view.status = 'error'
       @latex.panel.view.showLog = true
       @latex.logger.processError(
-        """Failed Building LaTeX (code #{err.code}).""", err.message, true,
+        title || """Failed Building LaTeX (code #{err.code}).""", err.message, true,
         [{
           text: "Dismiss"
           onDidClick: => @latex.logger.clearBuildError()
@@ -133,10 +133,13 @@ class Builder extends Disposable
       })
       # Kill entire process tree
       if process.platform is 'win32'
-        cp.exec("taskkill -pid #{@currentProcess.pid} /T /F")
+        killcmd = "taskkill -pid #{@currentProcess.pid} /T /F"
       else
-        cp.exec("pkill -P #{@currentProcess.pid}")  
-      @currentProcess.kill()
+        killcmd = "pkill -P #{@currentProcess.pid}"
+      cp.exec(killcmd, (error, stdout, stderr) ->
+        console.log error if error?
+        console.log "> #{killcmd}\n\n#{stdout}" if stdout?
+        console.log stderr if stderr)
 
   binCheck: (binary) ->
     if hb.sync binary


### PR DESCRIPTION
Should kill all child process when utilising latex builders such as `latexmk` or `arara`.

Tested on Windows, but needs some testing on MacOS and Unix.

Fixes #54 