### PR TITLE
Changes required for upcoming CoffeeScript upgrade

### DIFF
--- a/spec/main-spec.coffee
+++ b/spec/main-spec.coffee
@@ -43,28 +43,28 @@ describe 'Atom-LaTeX', ->
       it 'compile if current file is a .tex file', ->
         helper.setConfig 'atom-latex.build_after_save', true
         project = """#{path.dirname(__filename)}#{path.sep}latex_project"""
-        waitsForPromise -> atom.workspace.open(
+        waitsForPromise -> (atom.workspace.open(
           """#{project}#{path.sep}input.tex""").then (editor) ->
             Promise.resolve editor.save()
-          .then () ->
+          ).then () ->
             expect(builder.build).toHaveBeenCalled()
 
       it 'does nothing if config disabled', ->
         helper.setConfig 'atom-latex.build_after_save', false
         project = """#{path.dirname(__filename)}#{path.sep}latex_project"""
-        waitsForPromise -> atom.workspace.open(
+        waitsForPromise -> (atom.workspace.open(
           """#{project}#{path.sep}input.tex""").then (editor) ->
             Promise.resolve editor.save()
-          .then () ->
+          ).then () ->
             expect(builder.build).not.toHaveBeenCalled()
 
       it 'does nothing if current file is not a .tex file', ->
         helper.setConfig 'atom-latex.build_after_save', true
         project = """#{path.dirname(__filename)}#{path.sep}latex_project"""
-        waitsForPromise -> atom.workspace.open(
+        waitsForPromise -> (atom.workspace.open(
           """#{project}#{path.sep}dummy.file""").then (editor) ->
             Promise.resolve editor.save()
-          .then () ->
+          ).then () ->
             expect(builder.build).not.toHaveBeenCalled()
 
     describe 'toolchain feature', ->


### PR DESCRIPTION
Hello!

In Atom 1.23.0, the CoffeeScript dependency [will be upgraded from version 1.11.1 to 1.12.7](https://github.com/atom/atom/pull/13731). To ensure that all packages will remain working the same way, we searched for CoffeeScript compile output differences from all Atom packages and found your package to be affected by the update.

This pull request implements the fix mentioned in https://github.com/jashkenas/coffeescript/issues/4760#issuecomment-340001235, which is compatible with both versions.

Please let me know if you have any questions.