### PR TITLE
Dismiss Failure Notification when "Show build log" Is Pressed

### DIFF
--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -96,7 +96,9 @@ class Builder extends Disposable
           onDidClick: => @latex.logger.clearBuildError()
         }, {
           text: "Show build log"
-          onDidClick: => @latex.logger.showLog()
+          onDidClick: ()=>
+            @latex.logger.clearBuildError()
+            @latex.logger.showLog()
         }]
       )
       @latex.logger.log.push({


### PR DESCRIPTION
Hello.

I find it useful to hide the notification when the "Show build log" button is pressed, since the full build log is going to appear in a new tab.

Thanks!
Philip