### PR TITLE
Autocompletion for custom commands now also account for the number of parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 npm-debug.log
 node_modules
+package-lock.json

--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -11,6 +11,59 @@ patterns: [
     name: "meta.space-after-command.latex"
   }
   {
+    match: "((\\\\)(begin)({)(figure|table)(}))(?:(\\[)([^\\]]*)(\\]))?"
+    captures:
+      "2":
+        name: "support.function.be.latex"
+      "3":
+        name: "support.function.be.latex"
+      "4":
+        name: "punctuation.section.group.begin.tex"
+      "5":
+        name: "variable.parameter.latex"
+      "6":
+        name: "punctuation.section.group.end.tex"
+      "7":
+        name: "punctuation.definition.arguments.begin.latex"
+      "8":
+        name: "variable.parameter.latex"
+      "9":
+        name: "punctuation.definition.arguments.end.latex"
+    name: "meta.begin.latex"
+    patterns: [
+      {
+        include: "$self"
+      }
+    ]
+  }
+  {
+    begin: "((\\\\)(includegraphics))(?:(\\[)([^\\]]*)(\\]))?(\\{)"
+    beginCaptures:
+      "1":
+        name: "keyword.control.label.latex"
+      "2":
+        name: "punctuation.definition.function.latex"
+      "3":
+        name: "punctuation.definition.arguments.begin.latex"
+      "4":
+        name: "variable.parameter.latex"
+      "5":
+        name: "punctuation.definition.arguments.end.latex"
+      "6":
+        name: "punctuation.definition.arguments.begin.latex"
+    contentName: "constant.other.reference.label.latex"
+    end: "\\}"
+    endCaptures:
+      "0":
+        name: "punctuation.definition.arguments.end.latex"
+    name: "meta.preamble.latex"
+    patterns: [
+      {
+        include: "$self"
+      }
+    ]
+  }
+  {
     begin: "((\\\\)(?:usepackage|documentclass))(?:(\\[)([^\\]]*)(\\]))?(\\{)"
     beginCaptures:
       "1":

--- a/lib/autocomplete/command.coffee
+++ b/lib/autocomplete/command.coffee
@@ -109,21 +109,28 @@ class Command extends Disposable
           counts: 1
       else
         items[result[1]].counts += 1
-      # Parse custom user-defined commands
-      newCommandReg = /\\(?:re|provide)?(?:new)?command(?:{)?\\(\w+)/g
-      loop
-        result = newCommandReg.exec content
-        break if !result?
-        if not (result[1] of items)
-          items[result[1]] =
-          displayText: result[1]
-          snippet: result[1] + '{$1}'
+      # Parse custom user-defined commands with fixed number of parameters TODO: optional parameters
+    newCommandReg = /\\(?:re|provide)?(?:new)?command(?:{)?\\(\w+)(?:})?(?:\[([0-9]+)\]{)?/g
+    loop
+      result = newCommandReg.exec content
+      break if !result?
+      if not (result[1] of items)
+        args_snippet = ''
+        args_display = ''
+        chainComplete = false
+        if result[2]
+          chainComplete = true
+          args_snippet += "{$#{i}}" for i in [1 .. parseInt(result[2],10)]
+          args_display += "{}" for i in [1 .. parseInt(result[2],10)]
+        items[result[1]] =
+          displayText: result[1] + args_display
+          snippet: result[1] + args_snippet
           type: 'function'
           latexType: 'command'
-          chainComplete: false
+          chainComplete: chainComplete
           counts: 1
-        else
-          items[result[1]].counts += 1
+      else
+        items[result[1]].counts += 1
     return items
 
   resetCommands: ->

--- a/lib/autocomplete/command.coffee
+++ b/lib/autocomplete/command.coffee
@@ -118,13 +118,15 @@ class Command extends Disposable
         args_snippet = ''
         args_display = ''
         chainComplete = false
+        number_of_param = 0
         if result[2]
+          number_of_param = parseInt(result[2],10)
           chainComplete = true
-          args_snippet += "{$#{i}}" for i in [1 .. parseInt(result[2],10)]
-          args_display += "{}" for i in [1 .. parseInt(result[2],10)]
+          args_snippet += "{$#{i}}" for i in [1 .. number_of_param]
+          args_display += "{}" for i in [1 .. number_of_param]
         items[result[1]] =
           displayText: result[1] + args_display
-          snippet: result[1] + args_snippet
+          snippet: result[1] + args_snippet + "$#{number_of_param + 1}"
           type: 'function'
           latexType: 'command'
           chainComplete: chainComplete

--- a/settings/language-latex.cson
+++ b/settings/language-latex.cson
@@ -6,7 +6,6 @@
     'commentStart': '% '
   'bracket-matcher':
     'autocompleteCharacters': [
-      '$$',
       '``',
       '{}',
       '()',


### PR DESCRIPTION
Hello, I have created a version for autocompletion which takes into account the number of parameters for a custom commands and adds a number of brackets accordingly. It does not account for optional parameters.

Also I have removed `$` auto-bracketing which in my opinion is not so useful because you have to step out from this by arrow keys which is slower in typing than type the end `$` character on your own. However, this is only my opinion.

Last but not least, I have added a grammar match for figure and table and includegraphics to exclude them from spell-checking by linter-spell-check.

You can decide what to merge into your branch.